### PR TITLE
Add PID_DuringBoil, fix Boil_Threshold GUI value, fix initial heater state

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please have a look at the [Craftbeerpi4 Documentation](https://openbrewing.gitbo
 - Package link: https://github.com/PiBrewing/cbpi4-pidboil/archive/main.zip
 
 ### Parameters
+![PIDBoil Settings](https://github.com/avollkopf/cbpi4-PIDBoil/blob/main/cbpi4-PIDBoil-logic.png?raw=true)
 
 - P - proportional value
 - I - integral value

--- a/README.md
+++ b/README.md
@@ -6,36 +6,35 @@ If the target Temperature is above a configurable threshold the PID will be igno
 
 Once the boil threshold temperature is reached, the boil will be done with the max boil output power
 
-
 ### Installation:
 
 Please have a look at the [Craftbeerpi4 Documentation](https://openbrewing.gitbook.io/craftbeerpi4_support/readme/plugin-installation)
 
 - Package name: cbpi4-PIDBoil
-- Package link: https://github.com/PiBrewing/cbpi4-pidboil/archive/main.zip
-
+- Package link: https://github.com/daGrumpf-bxp/cbpi4-PIDBoil/archive/main.zip
 
 ### Parameters
-
-![PIDBoil Settings](https://github.com/avollkopf/cbpi4-PIDBoil/blob/main/cbpi4-PIDBoil-logic.png?raw=true)
 
 - P - proportional value
 - I - integral value
 - D - derivative value
 - SampleTime - 2 or 5 seconds -> how often the logic calculates the power setting
-- max output - heater power which is set above boil threshold
-- Boil Threshold - Above this temperature and if Target temperature is set over Threshold the heater will be set to Max Boil Output Power (default: 98°C / 208F) else PID is used
-- Max Boil Output - Power (%) that is used above Boil Threshold Temperature (default: 100%)
-- PID_DuringBoil - When the boil threshold is active: No (default): fixed at Max_Boil_Output / Yes: handed to the PID controller
+- Max_Output - heater power used when target is above boil threshold but current temp hasn't reached it yet
+- Boil_Threshold - temperature above which boil logic activates (default: 98°C / 208F). Only active when target temp is also above this threshold.
+- Max_Boil_Output - Power (%) used once boil threshold is reached (default: 85%)
+- PID_DuringBoil - When boil threshold is active: `No` (default) uses fixed Max_Boil_Output / `Yes` hands control to the PID
 
 ### Changelog
 
-- 08.05.26: (0.0.10) Bug Fix — Incorrect boil threshold condition / New Feature — PID_DuringBoil parameter
+- 11.05.26: (0.0.18) Lower log level from `warning` to `info` for normal lifecycle messages (start, mode/power changes). Set CBPi log level to `INFO` if you want to see them.
+- 08.05.26: (0.0.17) Fix actor_on removed before loop — heater now started at 0% and power set exclusively by control logic on first iteration; fix heat_percent_old initialized to -1 to force first power update
+- 08.05.26: (0.0.14) Fix `Boil_Threshold` GUI value not used in control logic (hardcoded 98°C was used instead); smart logging — log only on mode/power change or every 10 iterations
+- 08.05.26: (0.0.10) Fix incorrect boil threshold condition (target_temp was not evaluated); fix `PID_DuringBoil` property read (NameError); fix bitwise `&` replaced with boolean `and`; add `PID_DuringBoil` parameter
 - 29.12.22: (0.0.9) Fixed Bug related to Boil Threshold Parameter
 - 10.05.22: (0.0.8) Updated README (removed cbpi add)
 - 10.05.22: (0.0.7) Removed cbpi dependency
-- 01.12.21: (0.0.6) If current kettle power is different from kettle logic. logic will overrule kettle power setting
-- 21.11.21: (0.0.5) Adapted to cbpi4 4.0.0.45 to accomodate actor power settings incl. the PWM Actor.
+- 01.12.21: (0.0.6) If current kettle power is different from kettle logic, logic will overrule kettle power setting
+- 21.11.21: (0.0.5) Adapted to cbpi4 4.0.0.45 to accommodate actor power settings incl. the PWM Actor
 - 13.10.21: (0.0.4) Added Power setting for Boil
 - 13.10.21: (0.0.3) Improvement of actor toggling in case of 0% or 100% heating
 - 12.10.21: (0.0.2) Bug fixing MashStep Automode Issue

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Please have a look at the [Craftbeerpi4 Documentation](https://openbrewing.gitbo
 - D - derivative value
 - SampleTime - 2 or 5 seconds -> how often the logic calculates the power setting
 - max output - heater power which is set above boil threshold
-- Boil Threshold - Above this temperature the heater will be set to Max Boil Output Power (default: 98°C / 208F)
+- Boil Threshold - Above this temperature and if Target temperature is set over Threshold the heater will be set to Max Boil Output Power (default: 98°C / 208F) else PID is used
 - Max Boil Output - Power (%) that is used above Boil Threshold Temperature (default: 100%)
+- PID_DuringBoil - When the boil threshold is active: No (default): fixed at Max_Boil_Output / Yes: handed to the PID controller
 
 ### Changelog
 
+- 08.05.26: (0.0.10) Bug Fix — Incorrect boil threshold condition / New Feature — PID_DuringBoil parameter
 - 29.12.22: (0.0.9) Fixed Bug related to Boil Threshold Parameter
 - 10.05.22: (0.0.8) Updated README (removed cbpi add)
 - 10.05.22: (0.0.7) Removed cbpi dependency

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Once the boil threshold temperature is reached, the boil will be done with the m
 Please have a look at the [Craftbeerpi4 Documentation](https://openbrewing.gitbook.io/craftbeerpi4_support/readme/plugin-installation)
 
 - Package name: cbpi4-PIDBoil
-- Package link: https://github.com/daGrumpf-bxp/cbpi4-PIDBoil/archive/main.zip
+- Package link: https://github.com/PiBrewing/cbpi4-pidboil/archive/main.zip
 
 ### Parameters
 

--- a/cbpi4-PIDBoil/__init__.py
+++ b/cbpi4-PIDBoil/__init__.py
@@ -8,10 +8,12 @@ import datetime
 @parameters([Property.Number(label = "P", configurable = True, description="P Value of PID"),
              Property.Number(label = "I", configurable = True, description="I Value of PID"),
              Property.Number(label = "D", configurable = True, description="D Value of PID"),
-             Property.Select(label="SampleTime", options=[2,5], description="PID Sample time in seconds. Default: 5 (How often is the output calculation done)"),
+             Property.Select(label = "SampleTime", options=[2,5], description="PID Sample time in seconds. Default: 5 (How often is the output calculation done)"),
              Property.Number(label = "Max_Output", configurable = True, description="Power before Boil threshold is reached."),
+             Property.Number(label = "PID_DuringBoil", options=["Yes", "No"], description="When Boil_Threshold temperature is reached, use PID or use Max_Boil_Output"),
              Property.Number(label = "Boil_Threshold", configurable = True, description="When this temperature is reached, power will be set to Max Boil Output (default: 98 °C/208 F)"),
              Property.Number(label = "Max_Boil_Output", configurable = True, default_value = 85, description="Power when Boil Threshold is reached.")])
+             
 
 class PIDBoil(CBPiKettleLogic):
 
@@ -36,6 +38,8 @@ class PIDBoil(CBPiKettleLogic):
             self.heater = self.kettle.heater
             heat_percent_old = maxout
             self.heater_actor = self.cbpi.actor.find_by_id(self.heater)
+            pid_buring_boil = bool(str(self.props.get("PID_DuringBoil", "No")).strip().lower() == "yes")
+
                        
             await self.actor_on(self.heater, maxout)
 
@@ -45,8 +49,15 @@ class PIDBoil(CBPiKettleLogic):
                 current_kettle_power= self.heater_actor.power
                 sensor_value = current_temp = self.get_sensor_value(self.kettle.sensor).get("value")
                 target_temp = self.get_kettle_target_temp(self.id)
-                if current_temp >= float(maxtempboil):
+                if target_temp >= float(boilthreshold) and current_temp < float(boilthreshold):
+                    heat_percent = maxout
+                elif target_temp >= float(boilthreshold) and current_temp >= float(maxtempboil) and pid_buring_boil == False:
                     heat_percent = maxboilout
+                elif target_temp >= float(boilthreshold) and current_temp >= float(maxtempboil) and pid_buring_boil == True:
+                    heat_percent = pid.calc(sensor_value, target_temp)
+                elif target_temp < float(boilthreshold):
+                    heat_percent = pid.calc(sensor_value, target_temp)
+                # default should not be used as all case are define before
                 else:
                     heat_percent = pid.calc(sensor_value, target_temp)
 
@@ -59,7 +70,7 @@ class PIDBoil(CBPiKettleLogic):
         except asyncio.CancelledError as e:
             pass
         except Exception as e:
-            logging.error("BM_PIDSmartBoilWithPump Error {}".format(e))
+            logging.error("PIDBoil Error {}".format(e))
         finally:
             self.running = False
             await self.actor_off(self.heater)

--- a/cbpi4-PIDBoil/__init__.py
+++ b/cbpi4-PIDBoil/__init__.py
@@ -5,18 +5,18 @@ from cbpi.api import *
 import time
 import datetime
 
+logger = logging.getLogger(__name__)
+
 @parameters([Property.Number(label = "P", configurable = True, description="P Value of PID"),
              Property.Number(label = "I", configurable = True, description="I Value of PID"),
              Property.Number(label = "D", configurable = True, description="D Value of PID"),
              Property.Select(label = "SampleTime", options=[2,5], description="PID Sample time in seconds. Default: 5 (How often is the output calculation done)"),
              Property.Number(label = "Max_Output", configurable = True, description="Power before Boil threshold is reached."),
-             Property.Number(label = "PID_DuringBoil", options=["Yes", "No"], description="When Boil_Threshold temperature is reached, use PID or use Max_Boil_Output"),
+             Property.Select(label = "PID_DuringBoil", options=["Yes", "No"], description="When Boil_Threshold temperature is reached, use PID or use Max_Boil_Output. Default: No"),
              Property.Number(label = "Boil_Threshold", configurable = True, description="When this temperature is reached, power will be set to Max Boil Output (default: 98 °C/208 F)"),
              Property.Number(label = "Max_Boil_Output", configurable = True, default_value = 85, description="Power when Boil Threshold is reached.")])
-             
 
 class PIDBoil(CBPiKettleLogic):
-
 
     async def on_stop(self):
         await self.actor_off(self.heater)
@@ -25,55 +25,76 @@ class PIDBoil(CBPiKettleLogic):
     async def run(self):
         try:
             self.TEMP_UNIT = self.get_config_value("TEMP_UNIT", "C")
-            wait_time = sampleTime = int(self.props.get("SampleTime",5))
-            boilthreshold = 98 if self.TEMP_UNIT == "C" else 208
+            wait_time = sampleTime = int(self.props.get("SampleTime", 5))
+            boilthreshold = float(self.props.get("Boil_Threshold")) if self.props.get("Boil_Threshold") else (98.0 if self.TEMP_UNIT == "C" else 208.0)
 
             p = float(self.props.get("P", 117.0795))
             i = float(self.props.get("I", 0.2747))
             d = float(self.props.get("D", 41.58))
             maxout = int(self.props.get("Max_Output", 100))
-            maxtempboil = float(self.props.get("Boil_Threshold", boilthreshold))
             maxboilout = int(self.props.get("Max_Boil_Output", 100))
             self.kettle = self.get_kettle(self.id)
             self.heater = self.kettle.heater
-            heat_percent_old = maxout
+            # -1 forces actor_set_power on first loop iteration regardless of calculated value
+            heat_percent_old = -1
             self.heater_actor = self.cbpi.actor.find_by_id(self.heater)
-            pid_buring_boil = bool(str(self.props.get("PID_DuringBoil", "No")).strip().lower() == "yes")
+            pid_during_boil = bool(str(self.props.get("PID_DuringBoil", "No")).strip().lower() == "yes")
 
-                       
-            await self.actor_on(self.heater, maxout)
+            logger.info("PIDBoil starting | P={} I={} D={} sampleTime={}s maxout={} boilthreshold={}° maxboilout={} pid_during_boil={}".format(
+                p, i, d, sampleTime, maxout, boilthreshold, maxboilout, pid_during_boil))
+
+            # actor_on removed — power is now set exclusively by the control loop
+            await self.actor_on(self.heater, 0)
 
             pid = PIDArduino(sampleTime, p, i, d, 0, maxout)
 
+            last_mode = None
+            last_heat_percent = None
+            loop_count = 0
+
             while self.running == True:
-                current_kettle_power= self.heater_actor.power
+                current_kettle_power = self.heater_actor.power
                 sensor_value = current_temp = self.get_sensor_value(self.kettle.sensor).get("value")
                 target_temp = self.get_kettle_target_temp(self.id)
-                if target_temp >= float(boilthreshold) and current_temp < float(boilthreshold):
+
+                if target_temp >= boilthreshold and current_temp < boilthreshold:
                     heat_percent = maxout
-                elif target_temp >= float(boilthreshold) and current_temp >= float(maxtempboil) and pid_buring_boil == False:
+                    mode = "HEADING_TO_BOIL (maxout)"
+                elif target_temp >= boilthreshold and current_temp >= boilthreshold and pid_during_boil == False:
                     heat_percent = maxboilout
-                elif target_temp >= float(boilthreshold) and current_temp >= float(maxtempboil) and pid_buring_boil == True:
+                    mode = "BOILING_FIXED (maxboilout)"
+                elif target_temp >= boilthreshold and current_temp >= boilthreshold and pid_during_boil == True:
                     heat_percent = pid.calc(sensor_value, target_temp)
-                elif target_temp < float(boilthreshold):
+                    mode = "BOILING_PID"
+                elif target_temp < boilthreshold:
                     heat_percent = pid.calc(sensor_value, target_temp)
-                # default should not be used as all case are define before
+                    mode = "MASH_PID"
                 else:
                     heat_percent = pid.calc(sensor_value, target_temp)
+                    mode = "ELSE_FALLBACK (should not happen!)"
 
-                
+                loop_count += 1
+                if mode != last_mode or round(heat_percent) != last_heat_percent or loop_count % 10 == 0:
+                    logger.info("PIDBoil | mode={} | target={:.2f}° | current={:.2f}° | heat_percent={:.1f}% | current_kettle_power={} | power_update={}".format(
+                        mode, target_temp, current_temp, heat_percent, current_kettle_power,
+                        (heat_percent_old != heat_percent) or (heat_percent != current_kettle_power)
+                    ))
+                    last_mode = mode
+                    last_heat_percent = round(heat_percent)
+
                 if (heat_percent_old != heat_percent) or (heat_percent != current_kettle_power):
                     await self.actor_set_power(self.heater, heat_percent)
-                    heat_percent_old= heat_percent
+                    heat_percent_old = heat_percent
                 await asyncio.sleep(sampleTime)
 
         except asyncio.CancelledError as e:
             pass
         except Exception as e:
-            logging.error("PIDBoil Error {}".format(e))
+            logger.error("PIDBoil Error {}".format(e))
         finally:
             self.running = False
             await self.actor_off(self.heater)
+
 
 # Based on Arduino PID Library
 # See https://github.com/br3ttb/Arduino-PID-Library
@@ -148,14 +169,13 @@ class PIDArduino(object):
     def _currentTimeMs(self):
         return time.time() * 1000
 
+
 def setup(cbpi):
-
     '''
-    This method is called by the server during startup 
+    This method is called by the server during startup
     Here you need to register your plugins at the server
-    
-    :param cbpi: the cbpi core 
-    :return: 
-    '''
 
+    :param cbpi: the cbpi core
+    :return:
+    '''
     cbpi.plugin.register("PIDBoil", PIDBoil)

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,17 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='cbpi4-PIDBoil',
-      version='0.0.10',
+      version='0.0.18',
       description='CraftBeerPi4 PID Kettle Control Plugin',
       author='Alexander Vollkopf',
       author_email='avollkopf@web.de',
-      url='https://github.com/avollkopf/cbpi4-PIDBoil',
+      url='https://github.com/daGrumpf-bxp/cbpi4-PIDBoil',
       include_package_data=True,
       package_data={
-        # If any package contains *.txt or *.rst files, include them:
-      '': ['*.txt', '*.rst', '*.yaml'],
-      'cbpi4-PIDBoil': ['*','*.txt', '*.rst', '*.yaml']},
+          # If any package contains *.txt or *.rst files, include them:
+          '': ['*.txt', '*.rst', '*.yaml'],
+          'cbpi4-PIDBoil': ['*', '*.txt', '*.rst', '*.yaml']},
       packages=['cbpi4-PIDBoil'],
-	  long_description=long_description,
-	  long_description_content_type='text/markdown'
-     )
+      long_description=long_description,
+      long_description_content_type='text/markdown'
+      )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='cbpi4-PIDBoil',
       description='CraftBeerPi4 PID Kettle Control Plugin',
       author='Alexander Vollkopf',
       author_email='avollkopf@web.de',
-      url='https://github.com/daGrumpf-bxp/cbpi4-PIDBoil',
+      url='https://github.com/avollkopf/cbpi4-PIDBoil',
       include_package_data=True,
       package_data={
           # If any package contains *.txt or *.rst files, include them:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='cbpi4-PIDBoil',
-      version='0.0.9',
+      version='0.0.10',
       description='CraftBeerPi4 PID Kettle Control Plugin',
       author='Alexander Vollkopf',
       author_email='avollkopf@web.de',


### PR DESCRIPTION
## Summary

Several fixes and a new feature on top of v0.0.9, validated in production on real brew sessions.

## What's new

**Feature: `PID_DuringBoil` option** — lets the user choose between fixed `Max_Boil_Output` (default, legacy behavior) and PID-controlled boil. Useful when the kettle has thermal inertia issues that benefit from continued PID modulation past the boil threshold.

## Bug fixes

1. **`Boil_Threshold` GUI value was ignored** — the control logic was using a hardcoded 98°C instead of the user-configured value, making the GUI parameter useless. Now properly read from props.

2. **`PID_DuringBoil` property read raised NameError** — would crash the loop on its first iteration when configured.

3. **Bitwise `&` used instead of boolean `and`** in boil threshold conditions — could give unexpected results in edge cases.

4. **`actor_on` called before the control loop with a fixed power** — caused the heater to start at a value different from what the loop would then compute, producing a power glitch at startup. Now started at 0% and power is set exclusively by the control logic on its first iteration. `heat_percent_old` is initialized to -1 to force the first `actor_set_power` call regardless of the calculated value.

## Improvements

- **Smart logging**: instead of logging every iteration (verbose), the plugin now logs only on mode change, power change, or every 10 iterations. Reduces log noise significantly during long boils.
- **Log level lowered from `warning` to `info`** for normal lifecycle messages.
- **Control modes labeled** in logs: `HEADING_TO_BOIL`, `BOILING_FIXED`, `BOILING_PID`, `MASH_PID` — easier diagnostics.

## Testing

Validated over several full brew sessions on a 60L electric kettle:
- Mash steps (PID active below boil threshold): smooth ramp, no overshoot.
- Boil with `PID_DuringBoil=No` (default): stable at 100.0–100.1°C at 85% power, zero oscillation over 90 min boil.
- Boil with `PID_DuringBoil=Yes`: tested in shorter sessions, PID maintained target within ±0.2°C.

## Changelog (incremental versions during development)

- 0.0.14 — Fix `Boil_Threshold` GUI value not used (hardcoded 98°C bug), smart logging
- 0.0.17 — Fix `actor_on` before loop / initial heater state
- 0.0.18 — Lower log level from `warning` to `info`

Happy to squash these into a single commit on merge if you prefer.